### PR TITLE
Evaluate g:phpfmt_autosave on save

### DIFF
--- a/autoload/phpfmt/fmt.vim
+++ b/autoload/phpfmt/fmt.vim
@@ -3,6 +3,12 @@ if exists('g:loaded_phpfmt_fmt_autoload') || !exists('g:loaded_phpfmt_plugin')
 endif
 let g:loaded_phpfmt_fmt_autoload = 1
 
+function! phpfmt#fmt#autoformat() abort "{{{
+    if get(g:, 'phpfmt_autosave', 1)
+        call phpfmt#fmt#format()
+    endif
+endfunction "}}}
+
 function! phpfmt#fmt#format() abort "{{{
     if g:phpfmt_experimental == 1
         " Using winsaveview to save/restore cursor state has the problem of

--- a/plugin/phpfmt.vim
+++ b/plugin/phpfmt.vim
@@ -40,7 +40,5 @@ command! -bar PhpFmt call phpfmt#fmt#format()
 
 augroup vim-phpfmt
     autocmd!
-    if get(g:, "phpfmt_autosave", 1)
-        autocmd BufWritePre *.php call phpfmt#fmt#format()
-    endif
+    autocmd BufWritePre *.php call phpfmt#fmt#autoformat()
 augroup END


### PR DESCRIPTION
This makes it possible to override the autosave behavior per directory,
for example with the localvimrc plugin.
