### PR TITLE
Issue #4 Broken File Permissions during Usage

### DIFF
--- a/autoload/phpfmt/fmt.vim
+++ b/autoload/phpfmt/fmt.vim
@@ -56,7 +56,11 @@ function! phpfmt#fmt#format() abort "{{{
     try | silent undojoin | catch | endtry
     " reload buffer
     let old_fileformat = &fileformat
-    call rename(l:tmpname, expand('%'))
+    let formatted_content = readfile(l:tmpname)
+    " copy the content from formatted tempfile
+    call writefile(formatted_content, expand('%'))
+    " delete tempfile
+    call delete(l:tmpname)
     silent edit!
     let &fileformat = old_fileformat
     let &syntax = &syntax


### PR DESCRIPTION
Cause: we make a copy of the file then format the copied file, but
this file's owner ship and permission are not preserved.

Solutions tried: 
1.  Investigated vim script's options to preserve file onwership while write a file, it seems to be not possible.
2. Investigated using cp -a or cp -p, unable to preserve owner.

Solution: overwrite file content of current file directly