### PR TITLE
Fix g:phpfmt_options problem and fit for phpcbf version 3

### DIFF
--- a/autoload/phpfmt/fmt.vim
+++ b/autoload/phpfmt/fmt.vim
@@ -34,7 +34,7 @@ function! phpfmt#fmt#format() abort "{{{
         endif
         let l:tmpname = g:phpfmt_tmp_dir . expand('%')
     else
-        let l:tmpname = tempname()
+        let l:tmpname = tempname() . '.' . expand('%:e')
     endif
     call writefile(getline(1, '$'), l:tmpname)
 

--- a/plugin/phpfmt.vim
+++ b/plugin/phpfmt.vim
@@ -27,9 +27,17 @@ if !exists('g:phpfmt_command')
 endif
 
 if !exists('g:phpfmt_standard')
-    let g:phpfmt_options = '--standard=PSR2 --encoding=utf-8'
+    let g:phpfmt_standard = 'PSR2'
 else
+    let phpmfm_standard_is_specified = 1
+endif
+
+if !exists('g:phpfmt_options')
     let g:phpfmt_options = '--standard=' . g:phpfmt_standard . ' --encoding=utf-8'
+else
+    if exists('phpmfm_standard_is_specified')
+        let g:phpfmt_options = '--standard=' . g:phpfmt_standard . ' ' . g:phpfmt_options
+    endif
 endif
 
 if !exists("g:phpfmt_experimental")


### PR DESCRIPTION
I found two problems about using g:phpfmt_options and phpcbf version 3. Sorry for my pull request include each two issues.

1. Fix g:phpfmt_options
When I set g:phpfmt_options on my .vimrc, it seemed doesn't work. So I modified treating g:phpfmt_options and g:phpfmt_standard on plugin/phpfmt.vim. My settings for vim-phpfmt is below:

```vimrc
let g:phpfmt_standard = 'PSR2'
let g:phpfmt_options = '--sniffs=Generic.WhiteSpace.ScopeIndent'
```

2. Fit for phpcbf version 3
I'm using phpcbf version 3.1.1. When I wrote a PHP code and do :PhpFmt, it doesn't work. Phpcbf version 3 assumes to be a file extension in a filename. If it is not an extension, phpcbf skips process. I added an extension end of a temporary filename.